### PR TITLE
Use scopes and active spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,15 +149,17 @@ Executor.execute(schema, query, middleware = SlowLog.openTracing() :: Nil)
 
 You would need and implicit instance of a `Tracer` available in the scope.
 
-In order to access field's active `Span` in the resolve function, you can use middleware attachment `SpanAttachment`:
+In order to access field's `span` in the resolve function, you can use middleware attachment `ScopeAttachment`:
 
 ```scala
 Fied(..., resolve = ctx ⇒ {
-  val parentSpan: Option[Span] = ctx.attachment[SpanAttachment].map(_.span)
+  val parentSpan: Option[Span] = ctx.attachment[ScopeAttachment].map(_.scope).map(_.span)
   
   // ...
 })
 ``` 
+
+The middleware creates spans using OpenTracings `startActive` API, so you can inject the active span into a carrier, for instance an HTTP request, if resolving a field requires a network request, and follow the trace in the responding service.
 
 ## License
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ homepage := Some(url("http://sangria-graphql.org"))
 licenses := Seq("Apache License, ASL Version 2.0" → url("http://www.apache.org/licenses/LICENSE-2.0"))
 
 scalaVersion := "2.12.6"
-crossScalaVersions := Seq("2.11.11", "2.12.6")
+crossScalaVersions := Seq("2.11.12", "2.12.6")
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ homepage := Some(url("http://sangria-graphql.org"))
 licenses := Seq("Apache License, ASL Version 2.0" → url("http://www.apache.org/licenses/LICENSE-2.0"))
 
 scalaVersion := "2.12.6"
-crossScalaVersions := Seq("2.11.12", "2.12.6")
+crossScalaVersions := Seq("2.11.11", "2.12.6")
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 

--- a/src/main/scala/sangria/slowlog/OpenTracing.scala
+++ b/src/main/scala/sangria/slowlog/OpenTracing.scala
@@ -86,4 +86,4 @@ class OpenTracing(parentSpan: Option[Span] = None, defaultOperationName: String 
     })
 }
 
-final case class ScopeAttachment(span: Scope) extends MiddlewareAttachment
+final case class ScopeAttachment(scope: Scope) extends MiddlewareAttachment


### PR DESCRIPTION
This allows for example fetchers to implement header handling
to connect with separate services.

Tell me if I'm wrong, but it shouldn't interfere with normal usage.