### PR TITLE
Fixes incorrect reference to SpanAttachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ In order to access field's `span` in the resolve function, you can use middlewar
 
 ```scala
 Fied(..., resolve = ctx ⇒ {
-  val parentSpan: Option[Span] = ctx.attachment[ScopeAttachment].map(_.span)
+  val parentSpan: Option[Span] = ctx.attachment[SpanAttachment].map(_.span)
   
   // ...
 })

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ You would need and implicit instance of a `Tracer` available in the scope.
 In order to access field's `span` in the resolve function, you can use middleware attachment `ScopeAttachment`:
 
 ```scala
-Fied(..., resolve = ctx ⇒ {
+Fied(..., resolve = ctx => {
   val parentSpan: Option[Span] = ctx.attachment[SpanAttachment].map(_.span)
   
   // ...


### PR DESCRIPTION
Just a wee bit of incorrect documentation. This addresses that.