### PR TITLE
optimize calculation of path (sangria 2.1.5)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.tools.mima.core.{DirectMissingMethodProblem, ProblemFilters}
+
 name := "sangria-slowlog"
 organization := "org.sangria-graphql"
 
@@ -16,6 +18,10 @@ ThisBuild / githubWorkflowBuildPreamble ++= List(
   WorkflowStep.Sbt(List("mimaReportBinaryIssues"), name = Some("Check binary compatibility")),
   WorkflowStep.Sbt(List("scalafmtCheckAll"), name = Some("Check formatting"))
 )
+// Binary Incompatible Changes, we'll document.
+ThisBuild / mimaBinaryIssueFilters ++= Seq(
+  ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.slowlog.SlowLog.even")
+)
 
 scalacOptions += "-target:jvm-1.8"
 javacOptions ++= Seq("-source", "8", "-target", "8")
@@ -23,7 +29,7 @@ javacOptions ++= Seq("-source", "8", "-target", "8")
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria" % "2.1.4",
+  "org.sangria-graphql" %% "sangria" % "2.1.5",
   "io.dropwizard.metrics" % "metrics-core" % "4.2.4",
   "org.slf4j" % "slf4j-api" % "1.7.32",
   "io.opentracing.contrib" %% "opentracing-scala-concurrent" % "0.0.6",

--- a/src/main/scala/sangria/slowlog/SlowLog.scala
+++ b/src/main/scala/sangria/slowlog/SlowLog.scala
@@ -92,15 +92,21 @@ class SlowLog(
       fieldVal: FieldVal,
       ctx: Context[Any, _],
       success: Boolean): Unit = {
-    val path = even(ctx.path.cacheKey)
+    val path = even(ctx.path.cacheKeyReversedIterator)
 
     queryVal.update(path, ctx.parentType.name, ctx.field.name, success, fieldVal, System.nanoTime())
   }
 
-  def even[T](v: Vector[T]): Vector[T] = v.iterator.zipWithIndex
-    .filter(_._2 % 2 == 0)
-    .map(_._1)
-    .toVector
+  private def even[T](v: Iterator[T]): Vector[T] = {
+    val l = new scala.collection.mutable.ListBuffer[T]()
+    var even = false
+    while (v.hasNext) {
+      val e = v.next()
+      if (even) l.prepend(e)
+      even = !even
+    }
+    l.toVector
+  }
 }
 
 object SlowLog {


### PR DESCRIPTION
This is only compatible with sangria [2.1.5](https://github.com/sangria-graphql/sangria/releases/tag/v2.1.5) and [3.0.0-RC5](https://github.com/sangria-graphql/sangria/releases/tag/v3.0.0-RC5).